### PR TITLE
Improve mobile navigation and collapsible sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
     <button class="btn" onclick="document.getElementById('projects').scrollIntoView({behavior:'smooth'})">View My Work</button>
   </header>
   <main>
-    <section id="about" class="collapsible">
-      <h2>About and Contact</h2>
+    <details id="about" class="collapsible">
+      <summary>About and Contact</summary>
       <div class="section-content">
       <div class="about-text">
         <p>
@@ -87,10 +87,10 @@
         </div>
       </div>
       </div>
-    </section>
+    </details>
 
-    <section id="certifications" class="collapsible">
-      <h2>Certifications</h2>
+    <details id="certifications" class="collapsible">
+      <summary>Certifications</summary>
       <div class="section-content">
       <div class="cert-list">
         <div class="cert-card">
@@ -153,10 +153,10 @@ web pages, a new certificate to complement my experience.</div>
         </div>
       </div>
       </div>
-    </section>
+    </details>
 
-    <section id="projects" class="collapsible">
-      <h2>Projects</h2>
+    <details id="projects" class="collapsible">
+      <summary>Projects</summary>
       <div class="section-content">
       <div class="projects-grid">
         <div class="project-card">
@@ -239,7 +239,7 @@ on save, and you're done! The program saves your portrait into your very own ico
         </div>
       </div> <!-- Project Grid -->
       </div>
-    </section> <!-- Projects -->
+    </details> <!-- Projects -->
   </main>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -85,14 +85,39 @@
       margin: 0 auto;
       padding: 1.5rem;
     }
-    section {
+    details.collapsible {
       background: var(--card);
       border-radius: var(--radius);
       margin-bottom: 2rem;
-      padding: 2rem 1.5rem;
       box-shadow: 0 4px 24px #0002;
       border: 1px solid var(--border);
       scroll-margin-top: 60px;
+    }
+    details.collapsible summary {
+      padding: 2rem 1.5rem;
+      margin: 0;
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      list-style: none;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    details.collapsible summary::-webkit-details-marker {
+      display: none;
+    }
+    details.collapsible summary::after {
+      content: '\25B6';
+      transition: transform var(--transition);
+      color: var(--accent);
+    }
+    details.collapsible[open] summary::after {
+      transform: rotate(90deg);
+    }
+    details.collapsible .section-content {
+      padding: 0 1.5rem 1.5rem 1.5rem;
     }
     #home, #skill{
       scroll-margin-top: 80px;
@@ -315,14 +340,32 @@
       main {
         padding: 1rem;
       }
-      section {
+      details.collapsible summary {
         padding: 1.2rem 0.7rem;
       }
       .projects-grid {
         grid-template-columns: 1fr;
       }
+      .cert-list {
+        flex-direction: column;
+        align-items: center;
+      }
+      .cert-card {
+        max-width: none;
+        width: 100%;
+        display: flex;
+        flex-direction: row;
+        text-align: left;
+        gap: 1rem;
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .cert-badge {
+        margin-bottom: 0;
+      }
       nav {
         gap: 1rem;
+        flex-wrap: wrap;
       }
     }
 


### PR DESCRIPTION
## Summary
- convert major content sections to `<details>` elements
- style collapsible sections with right-aligned arrows
- tweak mobile nav layout to prevent horizontal overflow
- make certification cards responsive and horizontal on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eb6ef5d8c832f841500a72bbe0c92